### PR TITLE
Removes portal storm event

### DIFF
--- a/code/modules/events/portal_storm.dm
+++ b/code/modules/events/portal_storm.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/portal_storm_syndicate
 	name = "Portal Storm: Syndicate Shocktroops"
 	typepath = /datum/round_event/portal_storm/syndicate_shocktroop
-	weight = 2
+	weight = 0 //Set to 1 or 2 if you want this enabled, you monster
 	min_players = 15
 	earliest_start = 18000
 


### PR DESCRIPTION
Alternative to: https://github.com/yogstation13/yogstation/pull/447/files

The only way to fix this is to remove this.

Sorry fluffy.

:cl: God
bugfix: Removes portal storm. It's existence is a bug, to me.
/:cl:
